### PR TITLE
Eliminates Redis PubSub from Streams implementation

### DIFF
--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -291,6 +291,8 @@ describe PUB_SUB_CLASS do
 
     @bus.publish("/foo", "two")
 
+    wait_for(100) { got.length == 1 }
+
     @bus.reset!
 
     @bus.publish("/foo", "three")

--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -297,7 +297,7 @@ describe PUB_SUB_CLASS do
 
     @bus.publish("/foo", "three")
 
-    wait_for(100) do
+    wait_for(2000) do
       got.length == 2
     end
 


### PR DESCRIPTION
Streams can be long-polled themselves, without the need to duplicate publishing to a PubSub channel.