### PR TITLE
Allow tracing the performance of middleware

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 - Unrelease
 
+  - FEATURE: Permit tracing middleware performance via `MessageBus.tracer` and
+    `MessageBus#on_middleware_attributes`.
+
 02-10-2020
 
 - Version 3.3.4

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -599,6 +599,24 @@ module MessageBus::Implementation
     @config[:client_message_filters]
   end
 
+  # @yieldparam [String] metric_name some name for the metric being recorded
+  def tracer(&blk)
+    @config[:tracer] = blk
+  end
+
+  # Executes the provided block of code within the context of a probe
+  # Intended to be managed by a consuming application which will define
+  # the `:tracer` config option.
+  #
+  # @param [String] metric_name some name for the metric being recorded
+  def trace(metric_name, &blk)
+    if @config[:tracer]
+      @config[:tracer].call(metric_name, &blk)
+    else
+      yield
+    end
+  end
+
   private
 
   ENCODE_SITE_TOKEN = "$|$"

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -617,6 +617,14 @@ module MessageBus::Implementation
     end
   end
 
+  # @yield [env] a routine to handle middleware decisions for tracing purposes
+  # @yieldparam [Hash<Symbol => Object>] attributes attributes detailing how message_bus handled the request
+  # @return [void]
+  def on_middleware_attributes(&blk)
+    configure(on_middleware_attributes: blk) if blk
+    @config[:on_middleware_attributes]
+  end
+
   private
 
   ENCODE_SITE_TOKEN = "$|$"

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -599,7 +599,17 @@ module MessageBus::Implementation
     @config[:client_message_filters]
   end
 
-  # @yieldparam [String] metric_name some name for the metric being recorded
+  # Used to trace the performance of various phases of the treatment of a client request
+  # @yieldparam [String] metric_name some name for the metric being recorded. Possible values include:
+  #   * messagebus/middleware/authentication
+  #   * messagebus/middleware/subscriptions
+  #   * messagebus/middleware/headers
+  #   * messagebus/middleware/check_chunked
+  #   * messagebus/middleware/calculate_backlog
+  #   * messagebus/middleware/immediate_response
+  #   * messagebus/middleware/setup_hijack
+  #   * messagebus/middleware/simple_poll
+  # @see `MessageBus::Rack::Middleware#call` for details of what happens in each phase
   def tracer(&blk)
     @config[:tracer] = blk
   end
@@ -620,6 +630,10 @@ module MessageBus::Implementation
   # @yield [env] a routine to handle middleware decisions for tracing purposes
   # @yieldparam [Hash<Symbol => Object>] attributes attributes detailing how message_bus handled the request
   # @return [void]
+  #
+  # The provided attributes are: `:messagebus_seq`, `:messagebus_query_string`, `:messagebus_client_count`,
+  # `:messagebus_long_polling`, `:messagebus_http_version`, `:messagebus_dont_chunk`, `:messagebus_allow_chunked`,
+  # `:messagebus_backlog_size`.
   def on_middleware_attributes(&blk)
     configure(on_middleware_attributes: blk) if blk
     @config[:on_middleware_attributes]

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -155,8 +155,12 @@ class MessageBus::Rack::Middleware
 
     if @bus.on_middleware_attributes
       @bus.on_middleware_attributes.call(
+        messagebus_seq: client.seq,
+        messagebus_query_string: env['QUERY_STRING'],
         messagebus_client_count: @connection_manager.client_count,
         messagebus_long_polling: long_polling,
+        messagebus_http_version: env['HTTP_VERSION'],
+        messagebus_dont_chunk: env['HTTP_DONT_CHUNK'],
         messagebus_allow_chunked: allow_chunked,
         messagebus_backlog_size: backlog.size
       )

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -81,45 +81,51 @@ class MessageBus::Rack::Middleware
     client_id = env['PATH_INFO'][@base_route_length..-1].split("/")[0]
     return [404, {}, ["not found"]] unless client_id
 
-    user_id = @bus.user_id_lookup.call(env) if @bus.user_id_lookup
-    group_ids = @bus.group_ids_lookup.call(env) if @bus.group_ids_lookup
-    site_id = @bus.site_id_lookup.call(env) if @bus.site_id_lookup
+    MessageBus.trace("middleware/authentication") do
+      user_id = @bus.user_id_lookup.call(env) if @bus.user_id_lookup
+      group_ids = @bus.group_ids_lookup.call(env) if @bus.group_ids_lookup
+      site_id = @bus.site_id_lookup.call(env) if @bus.site_id_lookup
+    end
 
     # close db connection as early as possible
     close_db_connection!
 
-    client = MessageBus::Client.new(message_bus: @bus, client_id: client_id,
-                                    user_id: user_id, site_id: site_id, group_ids: group_ids)
+    MessageBus.trace("middleware/subscriptions") do
+      client = MessageBus::Client.new(message_bus: @bus, client_id: client_id,
+                                      user_id: user_id, site_id: site_id, group_ids: group_ids)
 
-    if channels = env['message_bus.channels']
-      if seq = env['message_bus.seq']
-        client.seq = seq.to_i
-      end
-      channels.each do |k, v|
-        client.subscribe(k, v)
-      end
-    else
-      request = Rack::Request.new(env)
-      is_json = request.content_type && request.content_type.include?('application/json')
-      data = is_json ? JSON.parse(request.body.read) : request.POST
-      data.each do |k, v|
-        if k == "__seq"
-          client.seq = v.to_i
-        else
+      if channels = env['message_bus.channels']
+        if seq = env['message_bus.seq']
+          client.seq = seq.to_i
+        end
+        channels.each do |k, v|
           client.subscribe(k, v)
+        end
+      else
+        request = Rack::Request.new(env)
+        is_json = request.content_type && request.content_type.include?('application/json')
+        data = is_json ? JSON.parse(request.body.read) : request.POST
+        data.each do |k, v|
+          if k == "__seq"
+            client.seq = v.to_i
+          else
+            client.subscribe(k, v)
+          end
         end
       end
     end
 
-    headers = {}
-    headers["Cache-Control"] = "must-revalidate, private, max-age=0"
-    headers["Content-Type"] = "application/json; charset=utf-8"
-    headers["Pragma"] = "no-cache"
-    headers["Expires"] = "0"
+    MessageBus.trace("middleware/headers") do
+      headers = {}
+      headers["Cache-Control"] = "must-revalidate, private, max-age=0"
+      headers["Content-Type"] = "application/json; charset=utf-8"
+      headers["Pragma"] = "no-cache"
+      headers["Expires"] = "0"
 
-    if @bus.extra_response_headers_lookup
-      @bus.extra_response_headers_lookup.call(env).each do |k, v|
-        headers[k] = v
+      if @bus.extra_response_headers_lookup
+        @bus.extra_response_headers_lookup.call(env).each do |k, v|
+          headers[k] = v
+        end
       end
     end
 
@@ -127,33 +133,41 @@ class MessageBus::Rack::Middleware
       return [200, headers, ["OK"]]
     end
 
-    long_polling = @bus.long_polling_enabled? &&
-                   env['QUERY_STRING'] !~ /dlp=t/ &&
-                   @connection_manager.client_count < @bus.max_active_clients
+    MessageBus.trace("middleware/check_chunked") do
+      long_polling = @bus.long_polling_enabled? &&
+                    env['QUERY_STRING'] !~ /dlp=t/ &&
+                    @connection_manager.client_count < @bus.max_active_clients
 
-    allow_chunked = env['HTTP_VERSION'] == 'HTTP/1.1'
-    allow_chunked &&= !env['HTTP_DONT_CHUNK']
-    allow_chunked &&= @bus.chunked_encoding_enabled?
+      allow_chunked = env['HTTP_VERSION'] == 'HTTP/1.1'
+      allow_chunked &&= !env['HTTP_DONT_CHUNK']
+      allow_chunked &&= @bus.chunked_encoding_enabled?
 
-    client.use_chunked = allow_chunked
+      client.use_chunked = allow_chunked
+    end
 
-    backlog = client.backlog
+    MessageBus.trace("middleware/calculate_backlog") do
+      backlog = client.backlog
+    end
 
     if backlog.length > 0 && !allow_chunked
-      client.close
-      @bus.logger.debug "Delivering backlog #{backlog} to client #{client_id} for user #{user_id}"
-      [200, headers, [self.class.backlog_to_json(backlog)]]
-    elsif long_polling && env['rack.hijack'] && @bus.rack_hijack_enabled?
-      io = env['rack.hijack'].call
-      # TODO disable client till deliver backlog is called
-      client.io = io
-      client.headers = headers
-      client.synchronize do
-        client.deliver_backlog(backlog)
-        add_client_with_timeout(client)
-        client.ensure_first_chunk_sent
+      MessageBus.trace("middleware/close_long_poll") do
+        client.close
+        @bus.logger.debug "Delivering backlog #{backlog} to client #{client_id} for user #{user_id}"
+        [200, headers, [self.class.backlog_to_json(backlog)]]
       end
-      [418, {}, ["I'm a teapot, undefined in spec"]]
+    elsif long_polling && env['rack.hijack'] && @bus.rack_hijack_enabled?
+      MessageBus.trace("middleware/setup_hijack") do
+        io = env['rack.hijack'].call
+        # TODO disable client till deliver backlog is called
+        client.io = io
+        client.headers = headers
+        client.synchronize do
+          client.deliver_backlog(backlog)
+          add_client_with_timeout(client)
+          client.ensure_first_chunk_sent
+        end
+        [418, {}, ["I'm a teapot, undefined in spec"]]
+      end
     elsif long_polling && env['async.callback']
       response = nil
       # load extension if needed
@@ -184,7 +198,9 @@ class MessageBus::Rack::Middleware
 
       throw :async
     else
-      [200, headers, [self.class.backlog_to_json(backlog)]]
+      MessageBus.trace("middleware/simple_poll") do
+        [200, headers, [self.class.backlog_to_json(backlog)]]
+      end
     end
   rescue => e
     if @bus.on_middleware_error && result = @bus.on_middleware_error.call(env, e)

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -81,7 +81,7 @@ class MessageBus::Rack::Middleware
     client_id = env['PATH_INFO'][@base_route_length..-1].split("/")[0]
     return [404, {}, ["not found"]] unless client_id
 
-    MessageBus.trace("middleware/authentication") do
+    MessageBus.trace("messagebus/middleware/authentication") do
       user_id = @bus.user_id_lookup.call(env) if @bus.user_id_lookup
       group_ids = @bus.group_ids_lookup.call(env) if @bus.group_ids_lookup
       site_id = @bus.site_id_lookup.call(env) if @bus.site_id_lookup
@@ -90,7 +90,7 @@ class MessageBus::Rack::Middleware
     # close db connection as early as possible
     close_db_connection!
 
-    MessageBus.trace("middleware/subscriptions") do
+    MessageBus.trace("messagebus/middleware/subscriptions") do
       client = MessageBus::Client.new(message_bus: @bus, client_id: client_id,
                                       user_id: user_id, site_id: site_id, group_ids: group_ids)
 
@@ -115,7 +115,7 @@ class MessageBus::Rack::Middleware
       end
     end
 
-    MessageBus.trace("middleware/headers") do
+    MessageBus.trace("messagebus/middleware/headers") do
       headers = {}
       headers["Cache-Control"] = "must-revalidate, private, max-age=0"
       headers["Content-Type"] = "application/json; charset=utf-8"
@@ -133,7 +133,7 @@ class MessageBus::Rack::Middleware
       return [200, headers, ["OK"]]
     end
 
-    MessageBus.trace("middleware/check_chunked") do
+    MessageBus.trace("messagebus/middleware/check_chunked") do
       long_polling = @bus.long_polling_enabled? &&
                     env['QUERY_STRING'] !~ /dlp=t/ &&
                     @connection_manager.client_count < @bus.max_active_clients
@@ -145,7 +145,7 @@ class MessageBus::Rack::Middleware
       client.use_chunked = allow_chunked
     end
 
-    MessageBus.trace("middleware/calculate_backlog") do
+    MessageBus.trace("messagebus/middleware/calculate_backlog") do
       backlog = client.backlog
     end
 
@@ -159,13 +159,13 @@ class MessageBus::Rack::Middleware
     end
 
     if backlog.length > 0 && !allow_chunked
-      MessageBus.trace("middleware/immediate_response") do
+      MessageBus.trace("messagebus/middleware/immediate_response") do
         client.close
         @bus.logger.debug "Delivering backlog #{backlog} to client #{client_id} for user #{user_id}"
         [200, headers, [self.class.backlog_to_json(backlog)]]
       end
     elsif long_polling && env['rack.hijack'] && @bus.rack_hijack_enabled?
-      MessageBus.trace("middleware/setup_hijack") do
+      MessageBus.trace("messagebus/middleware/setup_hijack") do
         io = env['rack.hijack'].call
         # TODO disable client till deliver backlog is called
         client.io = io
@@ -207,7 +207,7 @@ class MessageBus::Rack::Middleware
 
       throw :async
     else
-      MessageBus.trace("middleware/simple_poll") do
+      MessageBus.trace("messagebus/middleware/simple_poll") do
         [200, headers, [self.class.backlog_to_json(backlog)]]
       end
     end

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -149,6 +149,14 @@ class MessageBus::Rack::Middleware
       backlog = client.backlog
     end
 
+    if @bus.on_middleware_attributes
+      @bus.on_middleware_attributes.call(
+        messagebus_long_polling: long_polling,
+        messagebus_allow_chunked: allow_chunked,
+        messagebus_backlog_size: backlog.size
+      )
+    end
+
     if backlog.length > 0 && !allow_chunked
       MessageBus.trace("middleware/close_long_poll") do
         client.close

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -151,6 +151,7 @@ class MessageBus::Rack::Middleware
 
     if @bus.on_middleware_attributes
       @bus.on_middleware_attributes.call(
+        messagebus_client_count: @connection_manager.client_count,
         messagebus_long_polling: long_polling,
         messagebus_allow_chunked: allow_chunked,
         messagebus_backlog_size: backlog.size

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -158,7 +158,7 @@ class MessageBus::Rack::Middleware
     end
 
     if backlog.length > 0 && !allow_chunked
-      MessageBus.trace("middleware/close_long_poll") do
+      MessageBus.trace("middleware/immediate_response") do
         client.close
         @bus.logger.debug "Delivering backlog #{backlog} to client #{client_id} for user #{user_id}"
         [200, headers, [self.class.backlog_to_json(backlog)]]


### PR DESCRIPTION
In a consuming application, when debugging slow responses to subscribing clients, it is useful to know where time is being spent in MessageBus middleware. This functionality allows hooking in a consumer-application-specific tracing mechanism, such as [NewRelic's `#trace_execution_scoped`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/MethodTracer#trace_execution_scoped-instance_method).
