### PR TITLE
Allow tracing the performance of middleware

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 - Unrelease
 
+  - FEATURE: Permit tracing middleware performance via `MessageBus.tracer` and
+    `MessageBus#on_middleware_attributes`.
+
 02-10-2020
 
 - Version 3.3.4

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -225,7 +225,6 @@
         "/poll" +
         (!longPoll ? "?dlp=t" : ""),
       data: data,
-      cache: false,
       async: true,
       dataType: dataType,
       type: "POST",

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -162,7 +162,8 @@ class MessageBus::Rack::Middleware
         messagebus_http_version: env['HTTP_VERSION'],
         messagebus_dont_chunk: env['HTTP_DONT_CHUNK'],
         messagebus_allow_chunked: allow_chunked,
-        messagebus_backlog_size: backlog.size
+        messagebus_backlog_size: backlog.size,
+        messagebus_subscription_count: client.subscriptions.count
       )
     end
 


### PR DESCRIPTION
In a consuming application, when debugging slow responses to subscribing clients, it is useful to know where time is being spent in MessageBus middleware. This functionality allows hooking in a consumer-application-specific tracing mechanism, such as [NewRelic's `#trace_execution_scoped`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/MethodTracer#trace_execution_scoped-instance_method).

Tracking some attributes of a connection will allow us to spot patterns in use of long polling/chunked encoding, etc.

Our use case involves `NewRelic::Agent::MethodTracer.trace_execution_scoped` and `NewRelic::Agent.add_custom_attributes` but the implementation here is agnostic of the tool used to record this data.
